### PR TITLE
chore: add magnum-cluster-api channel

### DIFF
--- a/communication/slack-config/channels.yaml
+++ b/communication/slack-config/channels.yaml
@@ -287,6 +287,7 @@ channels:
   - name: litmus
   - name: litmus-dev
   - name: lokomotive
+  - name: magnum-cluster-api
   - name: malaysia-users
   - name: malta-users
   - name: meet-our-contributors


### PR DESCRIPTION
This is a request for the [Cluster API driver for Magnum](https://github.com/vexxhost/magnum-cluster-api) project to get a channel in the Kubernetes 
Slack.

The project allows you to deploy Kuberentes clusters using the Cluster API for OpenStack, it enables users of OpenStack to make use of the Cluster API to 
get a fully integrated cluster wtih the underlying cloud using the Cloud Provider for OpenStack (CCM), Cinder CSI, Manila CSI, etc.

The project is fully open sourced, there are several contributors from different organizations and with the increased volume of PRs, we wanted to have a 
space that new users can talk and ask about it, but also a space for existing developers to discuss the project.

